### PR TITLE
Prefer domain in page URLs, display SNI in deploy summary

### DIFF
--- a/src/meridian/commands/client.py
+++ b/src/meridian/commands/client.py
@@ -139,7 +139,8 @@ def _deploy_client_page(
         warn(f"Could not deploy server-hosted connection page: {upload_error}")
         return ""
 
-    return f"https://{server_ip}/{info_page_path}/{reality_uuid}/"
+    host = domain or server_ip
+    return f"https://{host}/{info_page_path}/{reality_uuid}/"
 
 
 def _remove_client_page(
@@ -371,7 +372,8 @@ def run_show(
     # Check for hosted page URL
     hosted_page_url = ""
     if creds.server.hosted_page and creds.panel.info_page_path and client_entry.reality_uuid:
-        hosted_page_url = f"https://{server_ip}/{creds.panel.info_page_path}/{client_entry.reality_uuid}/"
+        host = creds.server.domain or server_ip
+        hosted_page_url = f"https://{host}/{creds.panel.info_page_path}/{client_entry.reality_uuid}/"
 
     # Print terminal output
     print_terminal_output(

--- a/src/meridian/commands/setup.py
+++ b/src/meridian/commands/setup.py
@@ -571,8 +571,8 @@ def _print_success(resolved: ResolvedServer, name: str, domain: str) -> None:
     if proxy_file.exists():
         creds = ServerCredentials.load(proxy_file)
         if creds.server.hosted_page and creds.panel.info_page_path and creds.reality.uuid:
-            ip = creds.server.ip or resolved.ip
-            hosted_page_url = f"https://{ip}/{creds.panel.info_page_path}/{creds.reality.uuid}/"
+            host = creds.server.domain or creds.server.ip or resolved.ip
+            hosted_page_url = f"https://{host}/{creds.panel.info_page_path}/{creds.reality.uuid}/"
 
     err_console.print("\n  [ok][bold]Done![/bold][/ok]\n")
     ok("Your proxy server is live and ready to use.")

--- a/src/meridian/commands/setup.py
+++ b/src/meridian/commands/setup.py
@@ -533,6 +533,8 @@ def _run_provisioner(
     info(f"Configuring server at {ctx.ip}...")
     if domain:
         info(f"Domain: {domain}")
+    if sni and sni != DEFAULT_SNI:
+        info(f"SNI: {sni}")
     if xhttp:
         info("XHTTP: enabled (enhanced stealth)")
     err_console.print()

--- a/src/meridian/provision/services.py
+++ b/src/meridian/provision/services.py
@@ -1059,7 +1059,8 @@ class DeployConnectionPage:
                 detail=upload_error,
             )
 
-        page_url = f"https://{self.server_ip}/{info_page_path}/{reality_uuid}/"
+        host = domain or self.server_ip
+        page_url = f"https://{host}/{info_page_path}/{reality_uuid}/"
         ctx["hosted_page_url"] = page_url
 
         return StepResult(


### PR DESCRIPTION
## Summary
Two small fixes for domain-mode deployments:                                                         
1. Connection page URLs (client add, client show, deploy output) now use the configured domain instead of always showing the raw server IP.            
2. Deploy summary now displays the SNI target when a non-default value is configured.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist
- [x] I have read `CONTRIBUTING.md`
- [x] `make ci` passes locally
- [x] Updated relevant documentation surfaces (see below)

### If modifying connection info templates:
- [ ] All connection-info templates are in sync (CSS/JS/app links)
- [ ] Tested light and dark mode

### If adding a new CLI command:
- [ ] Added help smoke test in `tests/test_cli.py`
- [ ] Updated README.md commands table
- [ ] Updated CLAUDE.md subcommands list

### If modifying credential handling:
- [ ] Tested with existing credential files (backward compat)
- [ ] Updated `ServerCredentials` dataclass if needed

### If modifying provisioner steps:
- [x] Step returns proper StepResult (ok/changed/skipped/failed)
- [x] ProvisionContext fields typed if used by other steps
- [x] Shell values use shlex.quote()
