### PR TITLE
Strip Docker credsStore on headless servers

### DIFF
--- a/src/meridian/provision/docker.py
+++ b/src/meridian/provision/docker.py
@@ -176,6 +176,18 @@ class InstallDocker:
         conn.run("systemctl start docker", timeout=15)
         conn.run("systemctl enable docker", timeout=15)
 
+        # Disable secretservice credential helper — headless servers lack D-Bus
+        # secret service, which makes `docker compose pull` fail even for
+        # public images.  Stripping credsStore lets Docker work without a
+        # keyring while preserving the rest of the config.
+        conn.run(
+            "test -f ~/.docker/config.json"
+            " && jq 'del(.credsStore)' ~/.docker/config.json > ~/.docker/config.json.tmp"
+            " && mv ~/.docker/config.json.tmp ~/.docker/config.json"
+            " || true",
+            timeout=15,
+        )
+
         return StepResult(name=self.name, status="changed")
 
 


### PR DESCRIPTION
## Summary
- Strip Docker's `credsStore` from `~/.docker/config.json` after installation to fix `docker compose pull` failures on headless servers lacking D-Bus secret service

## Test plan
- Verified on QA server that `jq 'del(.credsStore)'` correctly strips the key while preserving other config
- No-ops safely when config file doesn't exist or has no `credsStore` key
- `make ci` passes (552 tests)

Closes #6