### PR TITLE
Add --exit-user for relay commands to allow separate SSH users

### DIFF
--- a/src/meridian/cli.py
+++ b/src/meridian/cli.py
@@ -387,12 +387,15 @@ def relay_deploy_cmd(
 @relay_app.command("list")
 def relay_list_cmd(
     exit: str = typer.Option("", "--exit", "-e", help="Filter by exit server (IP or name)"),
-    user: str = typer.Option("", "--user", "-u", help="SSH user"),
+    user: str = typer.Option("", "--user", "-u", help="SSH user for the relay (defaults to registry entry or 'root')"),
+    exit_user: str = typer.Option(
+        "", "--exit-user", help="SSH user for the exit (defaults to registry entry or 'root')"
+    ),
 ) -> None:
     """List relay nodes."""
     from meridian.commands.relay import run_list
 
-    run_list(exit, user)
+    run_list(exit, user, exit_user=exit_user)
 
 
 @relay_app.command("remove")

--- a/src/meridian/cli.py
+++ b/src/meridian/cli.py
@@ -361,7 +361,10 @@ def update_cmd() -> None:
 def relay_deploy_cmd(
     relay_ip: str = typer.Argument(..., help="Relay server IP address"),
     exit: str = typer.Option(..., "--exit", "-e", help="Exit server (IP or name)"),
-    user: str = typer.Option("root", "--user", "-u", help="SSH user"),
+    user: str = typer.Option("", "--user", "-u", help="SSH user for the relay (defaults to registry entry or 'root')"),
+    exit_user: str = typer.Option(
+        "", "--exit-user", help="SSH user for the exit (defaults to registry entry or 'root')"
+    ),
     name: str = typer.Option("", "--name", help="Friendly name for the relay (e.g., ru-moscow)"),
     port: int = typer.Option(443, "--port", "-p", help="Relay listen port"),
     sni: str = typer.Option("", "--sni", help="Reality SNI target for relay (auto-scanned if omitted)"),
@@ -374,10 +377,11 @@ def relay_deploy_cmd(
       [cyan]meridian relay deploy 1.2.3.4 --exit 5.6.7.8[/cyan]
       [cyan]meridian relay deploy 1.2.3.4 --exit myserver --name ru-moscow[/cyan]
       [cyan]meridian relay deploy 1.2.3.4 --exit 5.6.7.8 --sni yandex.ru[/cyan]
+      [cyan]meridian relay deploy 1.2.3.4 -u alice --exit 5.6.7.8 --exit-user bob[/cyan]
     """
     from meridian.commands.relay import run_deploy
 
-    run_deploy(relay_ip, exit, user, name, port, yes, sni=sni, ssh_port=ssh_port)
+    run_deploy(relay_ip, exit, user, name, port, yes, sni=sni, ssh_port=ssh_port, exit_user=exit_user)
 
 
 @relay_app.command("list")
@@ -395,25 +399,31 @@ def relay_list_cmd(
 def relay_remove_cmd(
     relay_ip: str = typer.Argument(..., help="Relay IP to remove"),
     exit: str = typer.Option("", "--exit", "-e", help="Exit server (IP or name)"),
-    user: str = typer.Option("", "--user", "-u", help="SSH user"),
+    user: str = typer.Option("", "--user", "-u", help="SSH user for the relay (defaults to registry entry or 'root')"),
+    exit_user: str = typer.Option(
+        "", "--exit-user", help="SSH user for the exit (defaults to registry entry or 'root')"
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ) -> None:
     """Remove a relay node."""
     from meridian.commands.relay import run_remove
 
-    run_remove(relay_ip, exit, user, yes)
+    run_remove(relay_ip, exit, user, yes, exit_user=exit_user)
 
 
 @relay_app.command("check")
 def relay_check_cmd(
     relay_ip: str = typer.Argument(..., help="Relay IP to check"),
     exit: str = typer.Option("", "--exit", "-e", help="Exit server (IP or name)"),
-    user: str = typer.Option("", "--user", "-u", help="SSH user"),
+    user: str = typer.Option("", "--user", "-u", help="SSH user for the relay (defaults to registry entry or 'root')"),
+    exit_user: str = typer.Option(
+        "", "--exit-user", help="SSH user for the exit (defaults to registry entry or 'root')"
+    ),
 ) -> None:
     """Check health of a relay node."""
     from meridian.commands.relay import run_check
 
-    run_check(relay_ip, exit, user)
+    run_check(relay_ip, exit, user, exit_user=exit_user)
 
 
 # =============================================================================

--- a/src/meridian/commands/relay.py
+++ b/src/meridian/commands/relay.py
@@ -511,12 +511,13 @@ def _regenerate_client_pages(
 def run_deploy(
     relay_ip: str,
     exit_arg: str,
-    user: str = "root",
+    user: str = "",
     relay_name: str = "",
     listen_port: int = 443,
     yes: bool = False,
     sni: str = "",
     ssh_port: int = 22,
+    exit_user: str = "",
 ) -> None:
     """Deploy a relay node that forwards traffic to an exit server."""
     # Validate relay IP
@@ -527,6 +528,7 @@ def run_deploy(
         fail(f"Invalid relay name: {relay_name}", hint="Use letters, numbers, hyphens, underscores", hint_type="user")
 
     registry = ServerRegistry(SERVERS_FILE)
+    relay_user = _relay_registry_user(registry, relay_ip, user)
 
     # --- Explain what a relay does ---
     err_console.print()
@@ -539,7 +541,7 @@ def run_deploy(
 
     # Resolve exit server
     info(f"Resolving exit server: {exit_arg}")
-    resolved_exit = _resolve_exit(registry, exit_arg, user, force_refresh=True)
+    resolved_exit = _resolve_exit(registry, exit_arg, exit_user, force_refresh=True)
     exit_creds = ServerCredentials.load(resolved_exit.creds_dir / "proxy.yml")
 
     # Check if relay already registered
@@ -569,8 +571,8 @@ def run_deploy(
     ok(f"Exit server verified: {resolved_exit.ip}")
 
     # Connect to relay server
-    info(f"Connecting to relay server: {relay_ip}")
-    relay_conn = ServerConnection(ip=relay_ip, user=user, port=ssh_port)
+    info(f"Connecting to relay server: {relay_user}@{relay_ip}")
+    relay_conn = ServerConnection(ip=relay_ip, user=relay_user, port=ssh_port)
     try:
         relay_conn.check_ssh()
     except SSHError as exc:
@@ -669,7 +671,7 @@ def run_deploy(
     from meridian.config import REALM_VERSION
 
     summary = (
-        f"Relay:    {user}@{relay_ip}:{listen_port}\n"
+        f"Relay:    {relay_user}@{relay_ip}:{listen_port}\n"
         f"Exit:     {resolved_exit.ip}:443\n"
         f"Engine:   Realm v{REALM_VERSION} (zero-copy TCP forwarder)\n"
         f"Name:     {relay_name or '(auto)'}\n"
@@ -686,7 +688,7 @@ def run_deploy(
     err_console.print()
 
     if not yes:
-        confirm(f"Deploy relay to {user}@{relay_ip}?")
+        confirm(f"Deploy relay to {relay_user}@{relay_ip}?")
     err_console.print()
 
     # Run relay provisioner
@@ -698,7 +700,7 @@ def run_deploy(
         exit_ip=resolved_exit.ip,
         exit_port=443,
         listen_port=listen_port,
-        user=user,
+        user=relay_user,
     )
 
     info(f"Configuring relay at {relay_ip}...")
@@ -774,7 +776,9 @@ def run_deploy(
 
     # Register relay in server registry
     if relay_ip != resolved_exit.ip:
-        registry.add(ServerEntry(host=relay_ip, user=user, name=relay_name, role=SERVER_ROLE_RELAY, port=ssh_port))
+        registry.add(
+            ServerEntry(host=relay_ip, user=relay_user, name=relay_name, role=SERVER_ROLE_RELAY, port=ssh_port)
+        )
 
     # Regenerate connection pages for all existing clients
     if exit_creds.clients:
@@ -909,6 +913,7 @@ def run_remove(
     exit_arg: str = "",
     user: str = "",
     yes: bool = False,
+    exit_user: str = "",
 ) -> None:
     """Remove a relay node."""
     if not is_ip(relay_ip):
@@ -918,7 +923,7 @@ def run_remove(
 
     # Find the exit server for this relay
     if exit_arg:
-        resolved_exit = _resolve_exit(registry, exit_arg, user, force_refresh=True)
+        resolved_exit = _resolve_exit(registry, exit_arg, exit_user, force_refresh=True)
     else:
         result = _find_exit_for_relay(relay_ip, force_refresh=True)
         if result is None:
@@ -1029,6 +1034,7 @@ def run_check(
     relay_ip: str,
     exit_arg: str = "",
     user: str = "",
+    exit_user: str = "",
 ) -> None:
     """Check health of a relay node."""
     if not is_ip(relay_ip):
@@ -1038,7 +1044,7 @@ def run_check(
 
     # Find exit server
     if exit_arg:
-        resolved_exit = _resolve_exit(registry, exit_arg, user)
+        resolved_exit = _resolve_exit(registry, exit_arg, exit_user)
     else:
         result = _find_exit_for_relay(relay_ip)
         if result is None:

--- a/src/meridian/commands/relay.py
+++ b/src/meridian/commands/relay.py
@@ -828,6 +828,7 @@ def run_deploy(
 def run_list(
     exit_arg: str = "",
     user: str = "",
+    exit_user: str = "",
 ) -> None:
     """List relay nodes attached to exit server(s)."""
     from rich.box import ROUNDED
@@ -837,7 +838,7 @@ def run_list(
 
     if exit_arg:
         # List relays for a specific exit
-        resolved = _resolve_exit(registry, exit_arg, user)
+        resolved = _resolve_exit(registry, exit_arg, exit_user)
         creds = ServerCredentials.load(resolved.creds_dir / "proxy.yml")
 
         if not creds.relays:

--- a/src/meridian/commands/scan.py
+++ b/src/meridian/commands/scan.py
@@ -16,6 +16,33 @@ from meridian.servers import ServerRegistry
 from meridian.ssh import ServerConnection
 
 
+def _is_valid_hostname(value: str) -> bool:
+    """Return True if value is a plausible DNS hostname.
+
+    Rejects anything with whitespace or characters outside the RFC 1123 label
+    alphabet, and labels that don't start/end with an alphanumeric. Stricter
+    than necessary by design — the cost of letting garbage through is a broken
+    Reality inbound on a live server.
+    """
+    if not value or len(value) > 253:
+        return False
+    labels = value.split(".")
+    if len(labels) < 2:
+        return False
+    for label in labels:
+        if not label or len(label) > 63:
+            return False
+        if not (label[0].isalnum() and label[-1].isalnum()):
+            return False
+        if any(not (ch.isalnum() or ch == "-") for ch in label):
+            return False
+    # Reject IPv4 literals — Reality serverNames must be DNS hostnames.
+    # An all-numeric TLD is the cheap discriminator.
+    if labels[-1].isdigit():
+        return False
+    return True
+
+
 def scan_for_sni(conn: ServerConnection, ip: str) -> list[str]:
     """Run RealiTLScanner on the server and return list of discovered SNI targets.
 
@@ -108,22 +135,37 @@ def scan_for_sni(conn: ServerConnection, ip: str) -> list[str]:
         return []
     csv_output = csv_result.stdout.strip()
 
-    if not csv_output or csv_output == "IP,ORIGIN,CERT_DOMAIN,CERT_ISSUER,GEO_CODE":
+    lines = csv_output.splitlines()
+    if not lines:
         return []
 
-    # Parse CSV: extract cert_domain (column 3), skip header, deduplicate, filter bad targets
+    # RealiTLScanner CSV header has shifted over time (5 columns → 11 columns
+    # with TLS/ALPN/CURVE/CERT_* details). Resolve CERT_DOMAIN by header name
+    # instead of a fixed index, so a future format change doesn't silently
+    # smuggle e.g. "TLS 1.3" into Xray's Reality serverNames.
+    header = [h.strip() for h in lines[0].split(",")]
+    try:
+        domain_idx = header.index("CERT_DOMAIN")
+        ip_idx = header.index("IP")
+    except ValueError:
+        return []
+
     domains: list[str] = []
-    for csv_line in csv_output.splitlines():
+    for csv_line in lines[1:]:
         parts = csv_line.split(",")
-        if len(parts) < 3:
+        if len(parts) <= max(domain_idx, ip_idx):
             continue
-        csv_ip, _origin, cert_domain = parts[0], parts[1], parts[2]
-        if csv_ip == "IP":
-            continue  # header
-        if not cert_domain:
+        csv_ip = parts[ip_idx].strip()
+        cert_domain = parts[domain_idx].strip()
+        if csv_ip == "IP" or not cert_domain:
             continue
         if cert_domain.startswith("*"):
             continue  # wildcard certs
+        # Defensive hostname validation — RFC 1123 letters/digits/hyphens/dots
+        # only. Rejects pre-parsed garbage like "TLS 1.3" before it can land
+        # in Reality settings.
+        if not _is_valid_hostname(cert_domain):
+            continue
         # Filter known-bad targets
         if any(
             bad in cert_domain.lower()

--- a/src/meridian/protocols.py
+++ b/src/meridian/protocols.py
@@ -368,6 +368,12 @@ class XHTTPProtocol(Protocol):
             return ""
         uuid = self._resolve_uuid(reality_uuid, wss_uuid)
         via = f"-via-{relay_name}" if relay_name else f"-via-{relay_ip}"
+        # relay_sni is intentionally ignored: the relay's per-relay SNI on the
+        # exit routes to a Reality-only Xray inbound (see commands/relay.py
+        # _deploy_relay_nginx). XHTTP terminates TLS at nginx, which serves
+        # the cert for server_name = exit domain/IP. Using relay_sni here would
+        # land XHTTP traffic on the Reality inbound and trigger its dest
+        # fallback (real upstream site returns 404 for the XHTTP path).
         return self.build_url(
             uuid,
             name,
@@ -375,7 +381,6 @@ class XHTTPProtocol(Protocol):
             port=relay_port,
             xhttp_path=xhttp_path,
             domain=creds.server.domain or "",
-            sni=relay_sni,
             connect_host=_bracket_ipv6(relay_ip),
             server_name=server_name,
             extra_suffix=via,

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -546,13 +546,25 @@ class TestBuildRelayUrl:
         url = XHTTPProtocol().build_relay_url("r-uuid", "", creds, "bob", "198.51.100.50")
         assert url == ""
 
-    def test_xhttp_relay_with_relay_sni(self) -> None:
+    def test_xhttp_relay_ignores_relay_sni(self) -> None:
+        # XHTTP TLS is terminated by nginx on the exit using its server_name
+        # cert (domain or exit IP). The relay's Reality SNI must NOT be used
+        # — it would route XHTTP traffic to the per-relay Reality inbound,
+        # whose dest fallback would return 404 for the XHTTP path.
         creds = _make_test_creds(domain="example.com", xhttp_path="xp123")
         url = XHTTPProtocol().build_relay_url(
             "r-uuid", "", creds, "bob", "198.51.100.50", relay_sni="yandex.ru", relay_name="moscow"
         )
-        assert "sni=yandex.ru" in url
-        assert "sni=example.com" not in url
+        assert "sni=example.com" in url
+        assert "sni=yandex.ru" not in url
+
+    def test_xhttp_relay_ip_mode_ignores_relay_sni(self) -> None:
+        creds = _make_test_creds(xhttp_path="xp123")
+        url = XHTTPProtocol().build_relay_url(
+            "r-uuid", "", creds, "bob", "198.51.100.50", relay_sni="yandex.ru", relay_name="moscow"
+        )
+        assert "sni=198.51.100.1" in url  # exit IP, not relay's Reality SNI
+        assert "sni=yandex.ru" not in url
 
     def test_wss_relay_url(self) -> None:
         creds = _make_test_creds(domain="example.com", ws_path="ws789")

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -660,6 +660,121 @@ class TestRelayStoredUser:
         relay_conn.check_ssh.assert_called_once()
         mock_conn_cls.assert_called_once_with(ip="1.2.3.4", user="ubuntu")
 
+    def test_deploy_uses_registry_user_by_default(self, sample_proxy_with_relays: Path) -> None:
+        from meridian.commands.relay import run_deploy
+
+        creds_dir = sample_proxy_with_relays.parent
+        resolved_exit = MagicMock()
+        resolved_exit.ip = "5.6.7.8"
+        resolved_exit.user = "root"
+        resolved_exit.local_mode = False
+        resolved_exit.creds_dir = creds_dir
+        resolved_exit.conn = MagicMock()
+
+        registry = MagicMock()
+        registry.find.return_value = MagicMock(user="ubuntu")
+        relay_conn = MagicMock()
+        # ss port check returns nothing in use, nc connectivity test succeeds
+        relay_conn.run.side_effect = [
+            MagicMock(returncode=1, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        provisioner = MagicMock()
+        provisioner.run.return_value = []
+
+        with (
+            patch("meridian.commands.relay._resolve_exit", return_value=resolved_exit),
+            patch("meridian.commands.relay.ServerRegistry", return_value=registry),
+            patch("meridian.commands.relay.ServerConnection", return_value=relay_conn) as mock_conn_cls,
+            patch("meridian.commands.relay._create_relay_inbound", return_value=True),
+            patch("meridian.commands.relay._deploy_relay_nginx", return_value=True),
+            patch("meridian.commands.relay._save_exit_credentials_with_sync"),
+            patch("meridian.commands.relay._save_relay_local"),
+            patch("meridian.commands.relay._regenerate_client_pages"),
+            patch("meridian.provision.steps.Provisioner", return_value=provisioner),
+        ):
+            run_deploy("2.3.4.5", "5.6.7.8", yes=True, sni="yandex.ru")
+
+        mock_conn_cls.assert_called_once_with(ip="2.3.4.5", user="ubuntu", port=22)
+        added_entry = registry.add.call_args[0][0]
+        assert added_entry.host == "2.3.4.5"
+
+    def test_deploy_separate_relay_and_exit_users(self, sample_proxy_with_relays: Path) -> None:
+        """--user and --exit-user must be passed independently to the right server."""
+        from meridian.commands.relay import run_deploy
+
+        creds_dir = sample_proxy_with_relays.parent
+        resolved_exit = MagicMock()
+        resolved_exit.ip = "5.6.7.8"
+        resolved_exit.user = "bob"
+        resolved_exit.local_mode = False
+        resolved_exit.creds_dir = creds_dir
+        resolved_exit.conn = MagicMock()
+
+        registry = MagicMock()
+        relay_conn = MagicMock()
+        relay_conn.run.side_effect = [
+            MagicMock(returncode=1, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        provisioner = MagicMock()
+        provisioner.run.return_value = []
+
+        with (
+            patch("meridian.commands.relay._resolve_exit", return_value=resolved_exit) as mock_resolve,
+            patch("meridian.commands.relay.ServerRegistry", return_value=registry),
+            patch("meridian.commands.relay.ServerConnection", return_value=relay_conn) as mock_conn_cls,
+            patch("meridian.commands.relay._create_relay_inbound", return_value=True),
+            patch("meridian.commands.relay._deploy_relay_nginx", return_value=True),
+            patch("meridian.commands.relay._save_exit_credentials_with_sync"),
+            patch("meridian.commands.relay._save_relay_local"),
+            patch("meridian.commands.relay._regenerate_client_pages"),
+            patch("meridian.provision.steps.Provisioner", return_value=provisioner),
+        ):
+            run_deploy("2.3.4.5", "5.6.7.8", user="alice", exit_user="bob", yes=True, sni="yandex.ru")
+
+        # Exit resolver received the exit user, NOT the relay user
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.args[2] == "bob"
+        # Relay SSH connection used the relay user
+        mock_conn_cls.assert_called_once_with(ip="2.3.4.5", user="alice", port=22)
+
+    def test_deploy_explicit_user_overrides_registry(self, sample_proxy_with_relays: Path) -> None:
+        from meridian.commands.relay import run_deploy
+
+        creds_dir = sample_proxy_with_relays.parent
+        resolved_exit = MagicMock()
+        resolved_exit.ip = "5.6.7.8"
+        resolved_exit.user = "root"
+        resolved_exit.local_mode = False
+        resolved_exit.creds_dir = creds_dir
+        resolved_exit.conn = MagicMock()
+
+        registry = MagicMock()
+        registry.find.return_value = MagicMock(user="ubuntu")
+        relay_conn = MagicMock()
+        relay_conn.run.side_effect = [
+            MagicMock(returncode=1, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        provisioner = MagicMock()
+        provisioner.run.return_value = []
+
+        with (
+            patch("meridian.commands.relay._resolve_exit", return_value=resolved_exit),
+            patch("meridian.commands.relay.ServerRegistry", return_value=registry),
+            patch("meridian.commands.relay.ServerConnection", return_value=relay_conn) as mock_conn_cls,
+            patch("meridian.commands.relay._create_relay_inbound", return_value=True),
+            patch("meridian.commands.relay._deploy_relay_nginx", return_value=True),
+            patch("meridian.commands.relay._save_exit_credentials_with_sync"),
+            patch("meridian.commands.relay._save_relay_local"),
+            patch("meridian.commands.relay._regenerate_client_pages"),
+            patch("meridian.provision.steps.Provisioner", return_value=provisioner),
+        ):
+            run_deploy("2.3.4.5", "5.6.7.8", user="root", yes=True, sni="yandex.ru")
+
+        mock_conn_cls.assert_called_once_with(ip="2.3.4.5", user="root", port=22)
+
     def test_check_uses_registry_user_by_default(self, sample_proxy_with_relays: Path) -> None:
         from meridian.commands.relay import run_check
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -204,10 +204,13 @@ class TestBuildRelayUrls:
         assert "sni=yandex.ru" in reality_url.url
         assert "sni=www.microsoft.com" not in reality_url.url
 
-        # XHTTP should also use relay SNI
+        # XHTTP must NOT use relay's Reality SNI — that SNI routes to a
+        # Reality-only Xray inbound on the exit. XHTTP terminates at nginx
+        # via the exit's server_name (domain or exit IP).
         xhttp_urls = [u for u in result.urls if u.key == "xhttp"]
         if xhttp_urls:
-            assert "sni=yandex.ru" in xhttp_urls[0].url
+            assert "sni=5.6.7.8" in xhttp_urls[0].url  # exit IP
+            assert "sni=yandex.ru" not in xhttp_urls[0].url
 
     def test_build_all_relay_urls_uses_relay_sni(self, sample_proxy_with_relays: Path) -> None:
         """build_all_relay_urls passes relay.sni from each RelayEntry."""


### PR DESCRIPTION
## Summary

Bundle of relay/protocol fixes:

- **`--exit-user` for relay commands.** `--user` now targets the relay server only. New `--exit-user` flag specifies the SSH user for the exit when it differs from the relay. Relay user defaults to the registry entry or `root`. Applies to `relay deploy`, `relay remove`, `relay check`, `relay list`.
- **XHTTP-via-relay URL using wrong SNI.** XHTTPProtocol.build_relay_url passed `relay_sni` to the URL, which on the exit routes to a Reality-only Xray inbound and triggers its dest fallback — the upstream site (e.g. api-maps.yandex.ru) then returned 404 for the XHTTP path. URLs now use the exit's domain/IP for SNI, matching the existing docstring contract in `urls.py`.
- **RealiTLScanner CSV format drift.** The scanner's output grew from 5 to 11 columns; `scan.py` took `parts[2]` as CERT_DOMAIN, which now points at the TLS column. Values like `"TLS 1.3"` were getting offered as SNI candidates and could end up in live Reality inbounds with `dest='TLS 1.3:443'` — every direct TLS handshake then hung 30s on the unresolvable dest. Header-based column lookup plus a hostname validator (rejects whitespace, single-label names, IPv4 literals) now keep garbage out of Xray config.

## Test plan

- [x] `make ci` (864 passed, 6 skipped, lint clean, templates render)
- [x] New tests: `test_xhttp_relay_ignores_relay_sni`, `test_xhttp_relay_ip_mode_ignores_relay_sni`; updated `test_build_relay_urls_with_relay_sni` and `test_build_relay_urls` to assert XHTTP SNI is exit domain/IP
- [x] Manual: XHTTP URL regen via `meridian client show` confirms `sni=<exit-ip>` (was `sni=<relay-sni>`)
- [ ] Optional: smoke test on a real domain-mode exit to confirm XHTTP-via-relay end-to-end (IP mode is still gated by ISP DPI on IP-literal SNI — separate concern, see follow-ups)

## Follow-ups (not in this PR)

- XHTTP-via-relay is still effectively unusable in IP-only mode (SNI=IP literal is killed by aggressive DPI on the client→relay leg). Consider hiding XHTTP relay URLs in `build_relay_urls` when no domain is configured.
- `meridian test` skips Connection tests when Ping has any issue, hiding working relay paths. Loosen this gate.
- RealiTLScanner segfaults on some networks (missing Country.mmdb) — report upstream.
- Existing servers deployed with the broken `"TLS 1.3"` SNI need manual recovery: their Xray Reality inbound has `dest='TLS 1.3:443'` and won't fix itself on redeploy (SNI change does not rebuild Xray inbounds by design). Could be addressed with a `meridian deploy --rebuild-reality` flag or a doctor check that flags inbound/creds SNI mismatch.