### PR TITLE
Fixed arch picker for RealiTLScanner

### DIFF
--- a/src/meridian/commands/scan.py
+++ b/src/meridian/commands/scan.py
@@ -30,10 +30,9 @@ def scan_for_sni(conn: ServerConnection, ip: str) -> list[str]:
     raw_arch = arch_result.stdout.strip()
     match raw_arch:
         case "x86_64":
-            arch = "64"
+            arch = "amd64"
         case "aarch64":
-            warn("RealiTLScanner has no arm64 build.")
-            return []
+            arch = "arm64"
         case _:
             warn(f"Unsupported architecture for scanner: {raw_arch}")
             return []


### PR DESCRIPTION
## Summary

Starting from https://github.com/XTLS/RealiTLScanner/releases/tag/v0.2.3 RealiTLScanner:

- provides arm64 linux builds
- the naming has changed to include the arch name

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist
- [x] I have read `CONTRIBUTING.md`
- [ ] `make ci` passes locally
- [ ] Updated relevant documentation surfaces (see below)

### If modifying connection info templates:
- [ ] All connection-info templates are in sync (CSS/JS/app links)
- [ ] Tested light and dark mode

### If adding a new CLI command:
- [ ] Added help smoke test in `tests/test_cli.py`
- [ ] Updated README.md commands table
- [ ] Updated CLAUDE.md subcommands list

### If modifying credential handling:
- [ ] Tested with existing credential files (backward compat)
- [ ] Updated `ServerCredentials` dataclass if needed

### If modifying provisioner steps:
- [ ] Step returns proper StepResult (ok/changed/skipped/failed)
- [ ] ProvisionContext fields typed if used by other steps
- [ ] Shell values use shlex.quote()
